### PR TITLE
fix prefer includes rule

### DIFF
--- a/lib/rules/prefer-includes.js
+++ b/lib/rules/prefer-includes.js
@@ -4,15 +4,17 @@
 module.exports = function(context) {
     return {
         ExpressionStatement: function(node) {
-            var left = node.expression.left;
-            var right = node.expression.right;
+            var expression = node.expression || {};
+            var left = expression.left || {};
+            var right = expression.right || {};
+            var operator = expression.operator;
+
+            var compareWithMinusOne = right.operator === '-' && right.argument.value === 1;
+            var lessThanZero = operator === '<' && right.value === 0;
             var isIndexOfEqualToMinusOne = left
                 && left.callee
                 && (left.callee.property.name === 'indexOf')
-                && (
-                    ((right.operator === '-') && (right.argument.value === 1))
-                    || (right.value > 0)
-                )
+                && (compareWithMinusOne || lessThanZero)
 
             if (isIndexOfEqualToMinusOne) {
                 context.report({

--- a/lib/rules/prefer-includes.js
+++ b/lib/rules/prefer-includes.js
@@ -11,10 +11,11 @@ module.exports = function(context) {
 
             var compareWithMinusOne = right.operator === '-' && right.argument.value === 1;
             var lessThanZero = operator === '<' && right.value === 0;
+            var moreOrEqualThanZero = operator === '>=' && right.value === 0;
             var isIndexOfEqualToMinusOne = left
                 && left.callee
                 && (left.callee.property.name === 'indexOf')
-                && (compareWithMinusOne || lessThanZero)
+                && (compareWithMinusOne || lessThanZero || moreOrEqualThanZero)
 
             if (isIndexOfEqualToMinusOne) {
                 context.report({


### PR DESCRIPTION
In my opinion, implementation of rule 'prefer-includes' cut off many "legal" use cases of indexOf.
If I'm not mistaken, Array/String.prototype.includes can replace only checking occurrences (comparing with -1 and inequalities less than 0, more or equal than 0).