### PR TITLE
Add tests for ESLint rules

### DIFF
--- a/docs/no-duplicated-chains.md
+++ b/docs/no-duplicated-chains.md
@@ -10,7 +10,7 @@ The following pattern is considered a warning:
 render() {
 	return (<div className={this.props.className}>
 		<p>{this.props.text}</p>
-	<div>)
+	</div>)
 }
 ```
 
@@ -22,7 +22,7 @@ render() {
 
 	return (<div className={className}>
 		<p>{text}</p>
-	<div>)
+	</div>)
 }
 ```
 
@@ -32,6 +32,6 @@ render() {
 
 	return (<div className={props.className}>
 		<p>{props.text}</p>
-	<div>)
+	</div>)
 }
 ```

--- a/docs/no-numeric-endings-for-variables.md
+++ b/docs/no-numeric-endings-for-variables.md
@@ -13,5 +13,5 @@ const user1 = 'Tony Stark';
 The following pattern is not considered a warning:
 
 ```js
-const ironMan = 'Tony Stark
+const ironMan = 'Tony Stark';
 ```

--- a/docs/no-then.md
+++ b/docs/no-then.md
@@ -23,6 +23,6 @@ async function getSomeData() {
   return fetch('http://some.url/')
 }
 
-const responst = await getSomeData()
+const response = await getSomeData()
 console.log(response);
 ```

--- a/docs/no-void-map.md
+++ b/docs/no-void-map.md
@@ -7,7 +7,7 @@ You have not to leave array.map without variable or property (bad example). Here
 The following pattern is considered a warning:
 
 ```js
-users.map(user=> user.status = "ACTIVE");
+users.map(user => user.status == "ACTIVE");
 ```
 
 The following pattern is not considered a warning:
@@ -22,6 +22,6 @@ const usersIds = users.map(user => user.id);
 ```js
 var users = [{id: 1}, {id: 2}, {id: 3}];
 
-users.map(user => user.id).forEach( id => { console.log(id) } );
+users.map(user => user.id).forEach(id => { console.log(id) } );
 
 ```

--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
       "node" : ">=6.0.0"
   },
   "scripts": {
-    "lint": "eslint ./"
+    "lint": "eslint ./",
+    "test": "jest",
+    "test:watch": "jest --watchAll"
   },
   "devDependencies": {
     "babel-eslint": "^7.1.1",
@@ -30,6 +32,12 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-no-require-lodash": "^1.1.0",
     "eslint-plugin-prefer-spread": "^1.0.3",
-    "eslint-plugin-react": "^6.10.0"
+    "eslint-plugin-react": "^6.10.0",
+    "jest": "23.6.0"
+  },
+  "jest": {
+    "testMatch": [
+      "**/tests/**/*.js"
+    ]
   }
 }

--- a/tests/lib/rules/classbody-starts-with-newline.js
+++ b/tests/lib/rules/classbody-starts-with-newline.js
@@ -1,0 +1,41 @@
+const rule = require('../../../lib/rules/classbody-starts-with-newline');
+const RuleTester = require('eslint/lib/testers/rule-tester');
+
+const parserOptions = { ecmaVersion: 6, sourceType: 'module' };
+
+const ruleTester = new RuleTester({ parserOptions });
+
+/* eslint-disable max-len */
+ruleTester.run('classbody-starts-with-newline', rule, {
+    valid: [
+        // FIXME: These fail but the documentation suggests they should pass
+        // {
+        //     code: 'export class SomeClass {\n  /**\n	 * Some comment\n	 */\n	constructor() {\n		super()\n	}\n}',
+        //     options: [ 'always' ]
+        // },
+        {
+            code: 'export class SomeClass {\n  /**\n	 * Some comment\n	 */\n	constructor() {\n		super()\n	}\n}',
+            options: [ 'never' ]
+        },
+        {
+            code: 'export class SomeClass {\n\n	constructor() {\n		super()\n	}\n}',
+            options: [ 'always' ]
+        },
+        {
+            code: 'export class SomeClass {\n	constructor() {\n		super()\n	}\n}',
+            options: [ 'never' ]
+        }
+    ],
+    invalid: [
+        {
+            code: 'export class SomeClass { \n	constructor() { \n		super() \n }\n}',
+            errors: [ { message: 'Start class body with a newline' } ],
+            options: [ 'always' ]
+        },
+        {
+            code: 'export class SomeClass { \n\n	constructor() { \n		super() \n }\n}',
+            errors: [ { message: 'Do not start class body with a newline' } ],
+            options: [ 'never' ]
+        }
+    ]
+});

--- a/tests/lib/rules/force-native-methods.js
+++ b/tests/lib/rules/force-native-methods.js
@@ -1,0 +1,27 @@
+const rule = require('../../../lib/rules/force-native-methods');
+const RuleTester = require('eslint/lib/testers/rule-tester');
+
+const parserOptions = { ecmaVersion: 6, sourceType: 'module' };
+
+const ruleTester = new RuleTester({ parserOptions });
+
+const message = 'Do not use lodash methods, use native instead';
+const errors = [ { message } ];
+
+/* eslint-disable max-len */
+ruleTester.run('force-native-methods', rule, {
+    valid: [
+        'numbers.filter(num => num % 2 === 0)',
+        'numbers.map(num => num + 1)'
+    ],
+    invalid: [
+        {
+            code: '_.filter(numbers, num => num % 2 === 0)',
+            errors
+        },
+        {
+            code: '_.map(numbers, num => num + 1)',
+            errors
+        }
+    ]
+});

--- a/tests/lib/rules/no-c-like-loops.js
+++ b/tests/lib/rules/no-c-like-loops.js
@@ -1,0 +1,29 @@
+const rule = require('../../../lib/rules/no-c-like-loops');
+const RuleTester = require('eslint/lib/testers/rule-tester');
+
+const parserOptions = { ecmaVersion: 6, sourceType: 'module' };
+
+const ruleTester = new RuleTester({ parserOptions });
+
+// eslint-disable-next-line max-len
+const message = 'Do not use c-like loop with i++ or i +=1, instead use forEach, Map, or For of';
+const errors = [ { message } ];
+
+/* eslint-disable max-len */
+ruleTester.run('no-c-like-loops', rule, {
+    valid: [
+        'list.forEach(function(item) { });',
+        'list.forEach((item) => { });',
+        'for (const item of list) { }'
+    ],
+    invalid: [
+        {
+            code: 'for (var i = 0; i < list.length; i++) { }',
+            errors
+        },
+        {
+            code: 'for (var i = 0; i < list.length; i += 1) { }',
+            errors
+        }
+    ]
+});

--- a/tests/lib/rules/no-duplicated-chains.js
+++ b/tests/lib/rules/no-duplicated-chains.js
@@ -1,0 +1,29 @@
+const rule = require('../../../lib/rules/no-duplicated-chains');
+const RuleTester = require('eslint/lib/testers/rule-tester');
+
+const parserOptions = {
+    ecmaFeatures: { jsx: true },
+    ecmaVersion: 6,
+    sourceType: 'module'
+};
+
+const ruleTester = new RuleTester({ parserOptions });
+
+/* eslint-disable max-len */
+ruleTester.run('no-duplicated-chains', rule, {
+    valid: [
+        'function render() {\n\tconst { className, text } = this.props;\n\treturn (<div className={className}>\n\t\t<p>{text}</p>\n\t</div>);\n}',
+        'function render() {\n\tconst props = this;\n\treturn (<div className={props.className}>\n\t\t<p>{props.text}</p>\n\t</div>);\n}'
+    ],
+    invalid: [
+        {
+            code: 'function render() {\n\treturn (<div className={this.props.className}>\n\t\t<p>{this.props.className}</p>\n\t</div>);\n}',
+            errors: [ { message: '' } ]
+        }
+        // FIXME: This passes but the documentation suggests it should fail
+        // {
+        //     code: 'function render() {\n\treturn (<div className={this.props.className}>\n\t\t<p>{this.props.text}</p>\n\t</div>);\n}',
+        //     errors: [ { message: '' } ]
+        // }
+    ]
+});

--- a/tests/lib/rules/no-numeric-endings-for-variables.js
+++ b/tests/lib/rules/no-numeric-endings-for-variables.js
@@ -1,0 +1,32 @@
+const rule = require('../../../lib/rules/no-numeric-endings-for-variables');
+const RuleTester = require('eslint/lib/testers/rule-tester');
+
+const parserOptions = { ecmaVersion: 6, sourceType: 'module' };
+
+const ruleTester = new RuleTester({ parserOptions });
+
+const message = 'Do not use variables with numeric endings';
+const errors = [ { message } ];
+
+/* eslint-disable max-len */
+ruleTester.run('no-numeric-endings-for-variables', rule, {
+    valid: [
+        "const ironMan = 'Tony Stark';",
+        'let foo = [];',
+        'var whatever = 5;'
+    ],
+    invalid: [
+        {
+            code: "const user1 = 'Tony Stark';",
+            errors
+        },
+        {
+            code: 'let foo1 = [];',
+            errors
+        },
+        {
+            code: 'var whatever42 = 5;',
+            errors
+        }
+    ]
+});

--- a/tests/lib/rules/no-then.js
+++ b/tests/lib/rules/no-then.js
@@ -1,0 +1,22 @@
+const rule = require('../../../lib/rules/no-then');
+const RuleTester = require('eslint/lib/testers/rule-tester');
+
+const parserOptions = { ecmaVersion: 2017, sourceType: 'module' };
+
+const ruleTester = new RuleTester({ parserOptions });
+
+const message = 'Do not use .then, instead use async / await';
+const errors = [ { message } ];
+
+/* eslint-disable max-len */
+ruleTester.run('no-then', rule, {
+    valid: [
+        'async function foo() { const response = await getSomeData(); console.log(response); }'
+    ],
+    invalid: [
+        {
+            code: 'function foo() { getSomeData().then(response => { console.log(response); }) }',
+            errors
+        }
+    ]
+});

--- a/tests/lib/rules/no-void-map.js
+++ b/tests/lib/rules/no-void-map.js
@@ -1,0 +1,22 @@
+const rule = require('../../../lib/rules/no-void-map');
+const RuleTester = require('eslint/lib/testers/rule-tester');
+
+const parserOptions = { ecmaVersion: 6, sourceType: 'module' };
+
+const ruleTester = new RuleTester({ parserOptions });
+
+const message = 'Here you have to assign this expression to variable or add other function to map';
+const errors = [ { message } ];
+
+/* eslint-disable max-len */
+ruleTester.run('no-void-map', rule, {
+    valid: [
+        'const userIds = users.map(user => user.id)'
+    ],
+    invalid: [
+        {
+            code: 'users.map(user => user.status == "ACTIVE")',
+            errors
+        }
+    ]
+});

--- a/tests/lib/rules/no-window.js
+++ b/tests/lib/rules/no-window.js
@@ -1,0 +1,30 @@
+const rule = require('../../../lib/rules/no-window');
+const RuleTester = require('eslint/lib/testers/rule-tester');
+
+const parserOptions = { ecmaVersion: 6, sourceType: 'module' };
+
+const ruleTester = new RuleTester({ parserOptions });
+
+const message = 'Avoid using window';
+const errors = [ { message } ];
+
+/* eslint-disable max-len */
+ruleTester.run('no-window', rule, {
+    valid: [
+        'let a; function foo() { a = 5; }'
+    ],
+    invalid: [
+        {
+            code: 'window.detail = 5;',
+            errors
+        },
+        {
+            code: 'function setDetail(detail) { window.detail = detail; }',
+            errors
+        },
+        {
+            code: 'function getDetail() { return window.detail; }',
+            errors
+        }
+    ]
+});

--- a/tests/lib/rules/prefer-includes.js
+++ b/tests/lib/rules/prefer-includes.js
@@ -1,0 +1,22 @@
+const rule = require('../../../lib/rules/prefer-includes');
+const RuleTester = require('eslint/lib/testers/rule-tester');
+
+const parserOptions = { ecmaVersion: 6, sourceType: 'module' };
+
+const ruleTester = new RuleTester({ parserOptions });
+
+const message = 'Do not use indexOf, instead use includes ';
+const errors = [ { message } ];
+
+/* eslint-disable max-len */
+ruleTester.run('prefer-includes', rule, {
+    valid: [
+        '[1, 2, 3, 4].includes(2)'
+    ],
+    invalid: [
+        {
+            code: '[1, 2, 3, 4].indexOf(2) === -1',
+            errors
+        }
+    ]
+});


### PR DESCRIPTION
Resolves #6. Thanks for tagging with Hacktoberfest and having good documentation!

This PR adds tests for all the rules in the project except for `no-filter-instead-of-find`, which already had tests. It also adds a test framework and test commands for running said tests (I picked Jest but it's easy to swap to whatever runner you'd prefer).

As part of writing these tests, I believe I found two bugs. I commented out the failing case and added a `FIXME` in both relevant tests:

* `classbody-starts-with-newline` throws an error for this code which the documentation suggests should pass:
```js
export class SomeClass {
    /**
     * Some comment
     */
    constructor() {
        super()
    }
}
```

* `no-duplicated-chains` passes this code but the documentation suggests it should throw an error:
```js
function render() {
    return (<div className={this.props.className}>
        <p>{this.props.text}</p>
    </div>);
}
```

This PR also corrects a few minor mistakes in the documentation.