### PR TITLE
Fixed missing plugin entry in recommended config

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,9 @@ module.exports = {
     },
     configs: {
         recommended: {
+            plugins: [
+                'more'
+            ],
             rules: {
                 'more/no-void-map': 2,
                 'more/no-c-like-loops': 2,


### PR DESCRIPTION
Recommended config should contain a `plugins` entry, so it can be used directly like:

```json
{
  "extends": [
    "plugin:more/recommended"
  ]
}
```

When users miss to add `"more"` to their `plugins` entry, they end up with the following errors (**this PR fixes the issue**):

```log
error: Definition for rule 'more/no-duplicated-chains' was not found (more/no-duplicated-chains) at .eslintrc.js:1:1:
> 1 | module.exports = {
    | ^
  2 |   env: {
  3 |     jest: true,
  4 |   },


error: Definition for rule 'more/classbody-starts-with-newline' was not found (more/classbody-starts-with-newline) at .eslintrc.js:1:1:
> 1 | module.exports = {
    | ^
  2 |   env: {
  3 |     jest: true,
  4 |   },


error: Definition for rule 'more/no-filter-instead-of-find' was not found (more/no-filter-instead-of-find) at .eslintrc.js:1:1:
> 1 | module.exports = {
    | ^
  2 |   env: {
  3 |     jest: true,
  4 |   },

[...]
```

**Note:** ESLint configs within plugins typically include the plugin. Ex:
- [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react/blob/master/index.js#L117-L119)
- [eslint-plugin-vue](https://github.com/vuejs/eslint-plugin-vue/blob/master/lib/configs/base.js#L19-L21)