### PR TITLE
Fixes #41 by evaluating expression names

### DIFF
--- a/lib/rules/no-window.js
+++ b/lib/rules/no-window.js
@@ -22,7 +22,7 @@ module.exports = function (context) {
         MemberExpression(node) {
             if (!node.object) return;
 
-            const objectName = node.object.name;
+            const objectName = node.object.name || (node.object.expression && node.object.expression.name);
 
             if (!isWindow(objectName)) return;
 


### PR DESCRIPTION
This adds a check for the `name` property nested in a `TSAsExpression`, which resolves #41.
